### PR TITLE
Add mapOptions prop to Collection component

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Visualizes a collection following the STAC-based collection description.
 - `version` (string): openEO version (defaults to `null`, which tries to auto-detect the version).
 - `collectionData` (object): A single STAC-based collection object as defined by the openEO API.
 - `initiallyCollapsed` (boolean): Allow collapsing/expanding the details and collapse the details by default (defaults to `false`).
-- `mapOptions` (object): For fine-tuning the behaviour of the map that displays the collection's spatial extent. Entirely optional. Possible keys and their default values:
-  - `height` (string) -- `"300px"`: Height of the map container div
-  - `width` (string) -- `"auto"`: Width of the map container div
-  - `wrapAroundAntimeridian` (boolean) -- `false`: Whether the world map wraps around the antimeridian (defined the other way round it's also known as "noWrap").
-  - `scrollWheelZoom` (boolean) -- `true`: Whether zooming via the mouse scroll wheel is enabled (regardless of this setting, buttons for `+` and `-` are _always_ displayed).
+- `mapOptions` (object): For fine-tuning the behaviour of the map that displays the collection's spatial extent. Entirely optional. Possible keys:
+  - `height` (string): Height of the map container div. Defaults to `"300px"`.
+  - `width` (string): Width of the map container div. Defaults to `"auto"`.
+  - `wrapAroundAntimeridian` (boolean): Whether the world map wraps around the antimeridian (defined the other way round it's also known as "noWrap"). Defaults to `false`.
+  - `scrollWheelZoom` (boolean): Whether zooming via the mouse scroll wheel is enabled (regardless of this setting, buttons for `+` and `-` are _always_ displayed). Defaults to `true`.
 
 **Slots:**
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ Visualizes a collection following the STAC-based collection description.
 - `version` (string): openEO version (defaults to `null`, which tries to auto-detect the version).
 - `collectionData` (object): A single STAC-based collection object as defined by the openEO API.
 - `initiallyCollapsed` (boolean): Allow collapsing/expanding the details and collapse the details by default (defaults to `false`).
+- `mapOptions` (object): For fine-tuning the behaviour of the map that displays the collection's spatial extent. Entirely optional. Possible keys and their default values:
+  - `height` (string) -- `"300px"`: Height of the map container div
+  - `width` (string) -- `"auto"`: Width of the map container div
+  - `wrapAroundAntimeridian` (boolean) -- `false`: Whether the world map wraps around the antimeridian (defined the other way round it's also known as "noWrap").
+  - `scrollWheelZoom` (boolean) -- `true`: Whether zooming via the mouse scroll wheel is enabled (regardless of this setting, buttons for `+` and `-` are _always_ displayed).
 
 **Slots:**
 

--- a/components/Collection.vue
+++ b/components/Collection.vue
@@ -340,7 +340,8 @@ export default {
 			default: false
 		},
 		mapOptions: {
-			default: function() { return {} },  // It's not possible to specify defaults for the individual properties, therefore this is handled in a computed property, and that function is easier when this prop is never `undefined`, hence the empty object (in a non-arrow factory function!).
+			// It's not possible to specify defaults for the individual properties, therefore this prop is only accessed through a computed property which adds them in.
+			default: function() { return {} },  // Don't remove! Must be a non-arrow factory function! When the prop is not given at all, this avoids having to deal with `undefined` in the computed-property-function.
 			validator: function(value) {
 				const allowedTypes = {  // keep in sync with Readme
 					height: "string",

--- a/components/Collection.vue
+++ b/components/Collection.vue
@@ -443,9 +443,9 @@ export default {
 				this.setMapSize(this.leafletOptions.height, this.leafletOptions.width);
 			} catch (e) {}
 		},
-		setMapSize(height, width = null) {
+		setMapSize(height, width) {
 			// Update map container in DOM
-			this.$refs.mapContainer.style.width = width ? width : 'auto';
+			this.$refs.mapContainer.style.width = width;
 			this.$refs.mapContainer.style.height = height;
 			this.map.instance.invalidateSize(true);
 			// Compute somewhat smart map extent and zoom level around bbox

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "contributors": [
     {
       "name": "Matthias Mohr"
+    },
+    {
+      "name": "Christoph Friedrich"
     }
   ],
   "description": "Common Vue components for openEO.",


### PR DESCRIPTION
Feature to provide optional settings for the behaviour of the map that displays the spatial extent of the collection.

I named it `mapOptions` and not `leafletOptions` on purpose so that it's library-independent. That's also the reason for naming `noWrap` differently (it's not a very speaking property name anyway and I don't like the negation).