### PR TITLE
Improve documentation of SupportedFileFormats

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,12 +147,12 @@ Visualizes the supported functionalities of the back-end.
 
 ### `SupportedFileFormats`
 
-Visualizes the supported output file formats of the back-end.
+Visualizes the supported file formats of the back-end.
 
 **Properties:**
 
 - `version` (string): openEO version
-- `formats` (object): Supported output formats as defined by the openEO API.
+- `formats` (object): Supported file formats as defined by the respective version of the openEO API.
 - `showInput` (boolean): Show the input file formats. Defaults to `false`.
 - `showOutput` (boolean): Show the output file formats. Defaults to `false`.
 


### PR DESCRIPTION
The term "*output* file formats" shouldn't appear in the general description of the component anymore.
Also, I think there should be a note that the expected structure of the `formats` prop differs depending on the value of `version`. I tried to express this with "as defined by the respective version" -- I'm not 100% happy with that wording yet, but I think it's better than before.