### PR TITLE
Fix wrong parameter name in docs of UdfRuntimes comp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Visualizes the supported UDF (user-defined function) runtimes of the back-end.
 **Properties:**
 
 - `version` (string): openEO version
-- `udfRuntimes` (object): Supported UDF runtimes as defined by the openEO API.
+- `runtimes` (object): Supported UDF runtimes as defined by the openEO API.
 
 **Methods:**
 


### PR DESCRIPTION
I just spent at least half an hour searching for the cause of an `undefined` in the Hub until I discovered that it was simply the docs stating the wrong parameter name 🙃🙃🙃